### PR TITLE
Optionally Pretty Print JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /kail
 /kail-linux
 /dist
+/.idea

--- a/cmd/kail/main.go
+++ b/cmd/kail/main.go
@@ -72,7 +72,7 @@ var (
 	flagGlogVmodule = kingpin.Flag("glog-vmodule", "glog -vmodule flag").
 			Default("").
 			String()
-	flagJsonPP = kingpin.Flag("jpp", "Json Pretty Print. If log lines are JSON, then pretty print them.").
+	flagJsonPP = kingpin.Flag("json-pp", "Json Pretty Print. If log lines are JSON, then pretty print them.").
 		Default("false").
 		Bool()
 )

--- a/cmd/kail/main.go
+++ b/cmd/kail/main.go
@@ -72,6 +72,9 @@ var (
 	flagGlogVmodule = kingpin.Flag("glog-vmodule", "glog -vmodule flag").
 			Default("").
 			String()
+	flagJsonPP = kingpin.Flag("jpp", "Json Pretty Print. If log lines are JSON, then pretty print them.").
+		Default("false").
+		Bool()
 )
 
 func main() {
@@ -270,7 +273,7 @@ func createController(
 
 func streamLogs(controller kail.Controller) {
 
-	writer := kail.NewWriter(os.Stdout)
+	writer := kail.NewWriter(os.Stdout, *flagJsonPP)
 
 	for {
 		select {

--- a/writer.go
+++ b/writer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fatih/color"
 	"encoding/json"
 	"bytes"
-	"io/ioutil"
 )
 
 var (
@@ -79,9 +78,5 @@ func tryJsonPrettyPrint(o []byte) []byte {
 	if err != nil {
 		return nil
 	}
-	bb, err := ioutil.ReadAll(t)
-	if err != nil {
-		return nil
-	}
-	return bb
+	return t.Bytes()
 }


### PR DESCRIPTION
Optionally pretty print JSON.

Add a flag, `--json-pp`, that attempts to pretty print log lines if they are JSON. If the line is not valid JSON, then print verbatim. 

I find this useful as I often `kail` logs produced via [`zap`](https://godoc.org/go.uber.org/zap), which are printed as JSON. Pretty printing them makes it much easier to visually parse. 