### PR TITLE
use different colors for different prefixes

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -211,12 +211,6 @@
 			"revisionTime": "2017-07-04T05:34:23Z"
 		},
 		{
-			"checksumSHA1": "aEU9IPbfuS1PWY2T26gn41y+feA=",
-			"path": "github.com/fatih/color",
-			"revision": "67c513e5729f918f5e69786686770c27141a4490",
-			"revisionTime": "2017-08-04T15:04:06Z"
-		},
-		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"path": "github.com/ghodss/yaml",
 			"revision": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7",
@@ -387,6 +381,12 @@
 			"path": "github.com/howeyc/gopass",
 			"revision": "bf9dde6d0d2c004a008c27aaee91170c786f6db8",
 			"revisionTime": "2017-01-09T16:22:49Z"
+		},
+		{
+			"checksumSHA1": "dO1kUjACBdfT6LLmIU1wEq40sk4=",
+			"path": "github.com/hpcloud/golor",
+			"revision": "dc1b58c471a0a01808e0c292210f4ce0efe50f83",
+			"revisionTime": "2015-09-14T22:10:10Z"
 		},
 		{
 			"checksumSHA1": "66lykxpWgSmQodnhkADqn6tnroQ=",

--- a/writer.go
+++ b/writer.go
@@ -4,11 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/fatih/color"
-)
-
-var (
-	prefixColor = color.New(color.FgHiWhite, color.Bold)
+	"github.com/hpcloud/golor"
 )
 
 type Writer interface {
@@ -31,10 +27,9 @@ func (w *writer) Print(ev Event) error {
 func (w *writer) Fprint(out io.Writer, ev Event) error {
 	prefix := w.prefix(ev)
 
-	if _, err := prefixColor.Fprint(out, prefix); err != nil {
-		return err
-	}
-	if _, err := prefixColor.Fprint(out, ": "); err != nil {
+	colorized := golor.Colorize(prefix+":", golor.AssignColor(prefix), -1)
+
+	if _, err := out.Write([]byte(colorized + " ")); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Hey, there are cases when you look for logs for some deployment where more than
1 replica is running. Now it's much easier to differ them, since for different
prefixes will be assigned different color.

Here is how it looks like:
![example](https://dead.archi/OcuKQlHTe4)