### PR TITLE
Capture logs from terminated containers

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -18,7 +18,7 @@ func NewContainerFilter(names []string) ContainerFilter {
 type containerFilter []string
 
 func (cf containerFilter) Accept(cs v1.ContainerStatus) bool {
-	if cs.State.Running == nil {
+	if cs.State.Running == nil && cs.State.Terminated == nil {
 		return false
 	}
 	if len(cf) == 0 {


### PR DESCRIPTION
If a container has a very short life, sometimes it is captured in the
logs collected by kail and sometimes not. This occurs when the container
exits before kail is able to see the container is alive and collect
logs. This should be a backwards compatible change since the
SinceSeconds value is generally quite small and still applies.

There appears to be a race condition elsewhere in kail (since at least 0.6) that causes logs to be duplicated from these short lived containers. This change does not exacerbate that issue, but does make it more visible as those container will show logs at least once now, and seem to be just as likely to show duplicate logs.

My particular use case has a series of short lived (<1 second) init containers that execute sequentially.