### PR TITLE
Write to /dev/stderr in a cross-platform way by default

### DIFF
--- a/cmd/kail/main.go
+++ b/cmd/kail/main.go
@@ -56,7 +56,6 @@ var (
 			Bool()
 
 	flagLogFile = kingpin.Flag("log-file", "log file output").
-			Default("/dev/stderr").
 			String()
 
 	flagLogLevel = kingpin.Flag("log-level", "log level").
@@ -148,12 +147,16 @@ func createLog() logutil.Log {
 	lvl, err := logrus.ParseLevel(*flagLogLevel)
 	kingpin.FatalIfError(err, "Invalid log level")
 
-	file, err := os.OpenFile(*flagLogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
-	kingpin.FatalIfError(err, "Error opening log file")
-
 	parent := logrus.New()
 	parent.Level = lvl
-	parent.Out = file
+
+	if *flagLogFile != "" {
+		file, err := os.OpenFile(*flagLogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+		kingpin.FatalIfError(err, "Error opening log file")
+		parent.Out = file
+	} else {
+		parent.Out = os.Stderr
+	}
 
 	return logutil_logrus.New(parent).WithComponent("kail.main")
 }


### PR DESCRIPTION
Windows doesn't have a `/dev/stderr` equivalent. I tried using `--log-file CON` but that didn't seem to work either. If the user doesn't specify a file, we can tell the logger to use `os.Stderr` by default instead, which obtains the stderr stream in a cross-platform way. This maintains existing compatibility while making the tool usable OOTB on windows.