### PR TITLE
Remove unused variable BINARY

### DIFF
--- a/godownloader.sh
+++ b/godownloader.sh
@@ -337,7 +337,6 @@ EOF
 PROJECT_NAME="kail"
 OWNER=boz
 REPO="kail"
-BINARY=kail
 FORMAT=tar.gz
 OS=$(uname_os)
 ARCH=$(uname_arch)


### PR DESCRIPTION
I run per default [Shellcheck](https://github.com/koalaman/shellcheck) on every script I run and for the godownloader.sh script it complains about an unused variable `BINARY`:

```
➜  ~ shellcheck /tmp/godownloader.sh 

In /tmp/godownloader.sh line 340:
BINARY=kail
^----^ SC2034: BINARY appears unused. Verify use (or export if used externally).

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- BINARY appears unused. Verify use...

```
This references to the line `BINARY=kail` in the main program of the script at this line https://github.com/boz/kail/blob/58d7816d3d93cccb1903603512e40919a843c760/godownloader.sh#L340

It seems to me that the BINARY variable is deprecated and not used any more as the REPO and PROJECT_NAME references to kail and we get from there the release data.
As I find it confusing and shellcheck should pass for any system related program with access to a possible production cluster IMHO,
I think it's either time to remove the BINARY completely or if it not intended, the PR is a wake up in case :-)