### PR TITLE
added github workflow for CI, added krew, updated homebrew 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+on:
+  push: 
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - 
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,3 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
-
 env:
   - GO111MODULE=on
 
@@ -9,40 +6,81 @@ before:
     - go mod download
 
 builds:
-- main: cmd/kail/main.go
-  binary: kail
-  goos:
-    - darwin
-    - linux
-  goarch:
-    - amd64
-    - arm
-    - arm64
-  env:
-    - CGO_ENABLED=0
+  - main: cmd/kail/main.go
+    binary: kail
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goamd64:
+      - v1
+      - v2
+      - v3
+    env:
+      - CGO_ENABLED=0
 
 brews:
-  -
-    tap:
+  - tap:
       owner: boz
       name: homebrew-repo
+      branch: master
+    goamd64: v2
     homepage: "https://github.com/boz/kail"
     description: "kubernetes tail - pod log viewer"
 
+krews:
+  - name: tail
+    goarm: 6
+    goamd64: v2
+    index:
+      owner: boz
+      name: krew-index
+      branch: master
+    homepage: "https://github.com/boz/kail"
+    description: |-
+      Kail https://github.com/boz/kail - "Just show me the logs"
+
+      Stream logs from all matched containers of all matched pods.  Match pods by service,
+      replicaset, deployment, and others.  Adjusts to a changing cluster - pods are
+      added and removed from logging as they fall in or out of the selection.
+
+      Documentation:
+        See https://github.com/boz/kail or
+        $ kubectl tail --help
+
+      Usage:
+        
+        # match all pods
+        $ kubectl tail
+        
+        # match pods in the 'frontend' namespace
+        $ kubectl tail --ns staging
+        
+        # match pods belonging to a replicaset named 'workers' in any namespace.
+        $ kubectl tail --rs workers
+        
+        # match pods belonging to the replicaset named 'workers' only in the 'staging' namespace
+        $ kubectl tail --rs staging/workers
+        
+        # match pods belonging to both the service "frontend" and the deployment "webapp"
+        $ kubectl tail --svc frontend --deploy webapp
+    short_description: "Stream logs from multiple pods and containers using simple, dynamic source selection."
+
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
 
 release:
   github:
     owner: boz
     name: kail
-  prerelease: false
-  draft: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,9 @@ brews:
       owner: boz
       name: homebrew-repo
       branch: master
+    commit_author:
+      name: boz
+      email: adam.boz@gmail.com
     goamd64: v2
     homepage: "https://github.com/boz/kail"
     description: "kubernetes tail - pod log viewer"
@@ -39,6 +42,9 @@ krews:
       owner: boz
       name: krew-index
       branch: master
+    commit_author:
+      name: boz
+      email: adam.boz@gmail.com
     homepage: "https://github.com/boz/kail"
     description: |-
       Kail https://github.com/boz/kail - "Just show me the logs"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ $ brew tap boz/repo
 $ brew install boz/repo/kail
 ```
 
+### Krew
+
+```sh
+$ kubectl krew install tail
+$ kubectl tail -h
+```
+
 ### Downloading
 
 Kail binaries for Linux and OSX can be found on the [latest release](https://github.com/boz/kail/releases/latest) page.  Download and install into your `$GOPATH/bin` with:


### PR DESCRIPTION
- added github workflow
- added krew publishing conf in goreleaser
- updated homebrew with more details
- support for arm64/apple silicon configured is end to end with ci


@boz: to make installation more easy for everybody who is using this awesome pluging, please do follow below steps.

> if you are busy you can add me as maintainer to repo, I will update as and when required, in our work place we use this heavily

1. you need to fork krew-index repo as boz/krew-index
2. once this is merged, you should create tag like 1.16.0
    - it will update homebrew tap file in boz/homebrew-repo
    - it will update krew manifest file in boz/krew-index
3. you need to create pull request from boz/krew-index to kubernetes-sigs/krew-index (upstream)


fix https://github.com/boz/kail/issues/68
fix https://github.com/boz/kail/issues/67