### PR TITLE
setup-go@v3 wrong detect go.mod version 1.20 as 1.2 - 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
           cache: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/boz/kail
 
-go 1.20
+go 1.21
 
 require (
 	github.com/boz/go-lifecycle v0.1.1


### PR DESCRIPTION
root reason https://github.com/boz/kail/actions/runs/6710981136/job/18237337728#step:4:21
failure https://github.com/boz/kail/actions/runs/6710981136/job/18237337728#step:6:32

change to v4 and switch to go 1.21 to avoid it