### PR TITLE
ci: add the permission `packages: write` to push images to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write # To push Docker images to ghcr.io
 
 jobs:
   goreleaser:


### PR DESCRIPTION
To resolve the error.

https://github.com/boz/kail/actions/runs/6711012036/job/18237432638

```
  ⨯ release failed after 12m59s              error=docker images: failed to publish artifacts: failed to push ghcr.io/boz/kail:v0.17.0-amd64 after 0 tries: failed to push ghcr.io/boz/kail:v0.17.0-amd64: exit status 1: denied: installation not allowed to Create organization package
```
