### PR TITLE
feat: regex filter pod name

### DIFF
--- a/cmd/kail/main.go
+++ b/cmd/kail/main.go
@@ -47,6 +47,7 @@ var (
 	flagJob         = kingpin.Flag("job", "job").Short('j').PlaceHolder("NAME").Strings()
 	flagNode        = kingpin.Flag("node", "node").PlaceHolder("NAME").Strings()
 	flagIng         = kingpin.Flag("ing", "ingress").PlaceHolder("NAME").Strings()
+	flagRegex       = kingpin.Flag("regex", "regex to filter pod name").PlaceHolder("REGEX").String()
 
 	flagContext = kingpin.Flag("context", "kubernetes context").PlaceHolder("CONTEXT-NAME").String()
 
@@ -286,6 +287,10 @@ func createDSBuilder() kail.DSBuilder {
 
 	if ids := parseIds("ing", *flagIng); len(ids) > 0 {
 		dsb = dsb.WithIngress(ids...)
+	}
+
+	if flagRegex != nil && *flagRegex != "" {
+		dsb = dsb.WithRegex(*flagRegex)
 	}
 
 	return dsb

--- a/ds_builder.go
+++ b/ds_builder.go
@@ -185,7 +185,7 @@ func (b *dsBuilder) Create(ctx context.Context, cs kubernetes.Interface) (DS, er
 		}
 	}
 	if len(b.regex) != 0 {
-		regexFilter, err := NameRegexFileter(b.regex)
+		regexFilter, err := NewNameRegexFilter(b.regex)
 		if err != nil {
 			ds.closeAll()
 			return nil, log.Err(err, "regex filter")

--- a/filter.go
+++ b/filter.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/nsname"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -75,7 +75,7 @@ func SourcesForPod(
 	return id, sources
 }
 
-func NameRegexFileter(regex string) (filter.Filter, error) {
+func NewNameRegexFilter(regex string) (filter.Filter, error) {
 	compile, err := regexp.Compile(regex)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Regular expression to filter podname

**Usage**:
`--regex "volcano-controllers.*"`
```bash
kail|master⚡ ⇒ go run cmd/kail/main.go --regex "volcano-controllers.*"
volcano-system/volcano-controllers-56588b7df6-stzxn[volcano-controllers]: 2024/01/19 06:05:52 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
volcano-system/volcano-controllers-56588b7df6-stzxn[volcano-controllers]: I0119 06:05:52.249537       1 flags.go:57] FLAG: --add-dir-header="false"
volcano-system/volcano-controllers-56588b7df6-stzxn[volcano-controllers]: I0119 06:05:52.249702       1 flags.go:57] FLAG: --alsologtostderr="false"
volcano-system/volcano-controllers-56588b7df6-stzxn[volcano-controllers]: I0119 06:05:52.249793       1 flags.go:57] FLAG: --ca-cert-file=""
volcano-system/volcano-controllers-56588b7df6-stzxn[volcano-controllers]: I0119 06:05:52.249836       1 flags.go:57] FLAG: --enable-healthz="true"
```
**Issue**:
#135 Support regular expression or auto completion?
I think this requirement is reasonable, and some scenes cannot be effectively filtered through leables, namesapce, etc.

